### PR TITLE
require `arrow-parens`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ We want to use generators. eslint: [`no-iterator`](http://eslint.org/docs/rules/
 ### ForOfStatement
 
 `for .. of` loops provide an easy way to iterate through iterators. eslint: [`no-restricted-syntax`](http://eslint.org/docs/rules/no-restricted-syntax)
+
+### Parentheses around function arguments in arrow functions
+
+We always want to use parentheses around function arguments in arrow functions to make it obvious what the function arguments are, even if it is just one argument

--- a/index.js
+++ b/index.js
@@ -12,5 +12,6 @@ module.exports = {
         "no-use-before-define": "off",
         "no-iterator": "off",
         "no-restricted-syntax": ["off", "ForOfStatement"],
+        "arrow-parens": ["error", "always"],
     }
 }


### PR DESCRIPTION
IMHO requiring `arrow-parens` makes it more obvious what the arguments for an arrow function are and disallows confusing (at least to me) things like:

```
const foo = argFn1 => (argFn2) => {
    // do something
    ...
}
```
(why is `argFn1 =>` not **allowed** to have parens, but `(argFn2) =>` is **required** to have them?)

but **requires** parentheses around the arguments for all arrow functions: 

```
const foo = (argFn1) => (argFn2) => {
    // do something
    ...
}
```