### PR TITLE
Allow anonymous functions

### DIFF
--- a/packages/eslint-config-actano-base/index.js
+++ b/packages/eslint-config-actano-base/index.js
@@ -7,6 +7,7 @@ module.exports = {
   ].map(require.resolve),
   "rules": {
     "semi": ["error", "never"],
+    "func-names": ["error", "never"],
     "no-underscore-dangle": "off",
     "no-constant-condition": "off",
     "no-iterator": "off",

--- a/packages/eslint-config-actano/index.js
+++ b/packages/eslint-config-actano/index.js
@@ -7,6 +7,7 @@ module.exports = {
   ].map(require.resolve),
   "rules": {
     "semi": ["error", "never"],
+    "func-names": ["error", "never"],
     "no-underscore-dangle": "off",
     "no-constant-condition": "off",
     "no-iterator": "off",


### PR DESCRIPTION
# Motivation
The intention of this change is to allow anonymous generator functions.

The server code of our application is continually converted to your new
"system borders" platform-API. An integral part of this API is the usage
of generator functions. A regular use-case is to provide first-class
generator functions as arguments to other functions. In this case it
usually doesn't make much sense to name the generator functions (the
same way regular functions don't have any name when using the arrow syntax).

Currently the linter configuration forces us to name these functions
anyway, forcing us to invent unnecessary function names.

# Hint
Unfortunately there is no distinction between anonymous functions and anonymous generator
functions in eslint. Therefore this change will also allow anonymous
regular functions.

# Links
- linter rule: https://eslint.org/docs/rules/func-names
- A test using the system-borders: https://github.com/actano/rplan/blob/bdc7849e94972cdf1aa136bd486e5a4f0d270b58/lib/aspect-calculated-raci-server/test/calculate-from-document.unit.js#L39
- An implementation using system-borders:
https://github.com/actano/rplan/blob/d81ee6f0d1cdce5d29d905426469d1604b3619ab/lib/invitation-server/src/rest-endpoints/accept-invitation.js#L21
